### PR TITLE
Upgrades todo-utils to latest to resolve API mismatch bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const colors = require('colors/safe');
 const Table = require('cli-table3');
 const {
-  readTodosSync,
+  readTodoData,
   isExpired,
   getDatePart,
   differenceInDays,
@@ -17,7 +17,7 @@ class TodoSummaryFormatter {
   print(
     results,
     todoInfo,
-    todos = this._readTodos(this.options.workingDir),
+    todos = readTodoData(this.options.workingDir),
     today = getDatePart()
   ) {
     let sorted = todos
@@ -30,8 +30,8 @@ class TodoSummaryFormatter {
           filePath: todo.filePath,
           dueIn: differenceInDays(today, new Date(todo.errorDate)),
           date: format(todo.errorDate),
-          isError: isExpired(todo.errorDate),
-          isWarn: isExpired(todo.warnDate),
+          isError: isExpired(todo.errorDate, today.getTime()),
+          isWarn: isExpired(todo.warnDate, today.getTime()),
         };
       });
 
@@ -67,10 +67,6 @@ class TodoSummaryFormatter {
 
       this.console.log(table.toString());
     }
-  }
-
-  _readTodos(baseDir) {
-    return [...readTodosSync(baseDir).values()];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^9.1.1",
+    "@ember-template-lint/todo-utils": "^10.0.0",
     "cli-table3": "^0.6.0",
     "colors": "^1.4.0",
     "strip-ansi": "6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,12 +294,12 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ember-template-lint/todo-utils@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-9.1.1.tgz#21765a8ffaf7f383331a77973ba06421f9283ce1"
-  integrity sha512-j3XcXhL2uBKI4MdR5ObaEK1yZwgeJoC4kYqnr47p/kET90UaOuX4NC1/pCyLmNEJYxCd3mA0WQihfZqPpW4biQ==
+"@ember-template-lint/todo-utils@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-10.0.0.tgz#085aafcf31ca04ba4d3a9460f088aed752b90ea8"
+  integrity sha512-US8VKnetBOl8KfKz+rXGsosz6rIETNwSz2F2frM8hIoJfF/d6ME1Iz1K7tPYZEE6SoKqZFlBs5XZPSmzRnabjA==
   dependencies:
-    "@types/eslint" "^7.2.12"
+    "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"
     slash "^3.0.0"
     tslib "^2.2.0"
@@ -702,10 +702,10 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/eslint@^7.2.12":
-  version "7.2.13"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.13.tgz#e0ca7219ba5ded402062ad6f926d491ebb29dd53"
-  integrity sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==
+"@types/eslint@^7.2.13":
+  version "7.28.2"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.2.tgz#0ff2947cdd305897c52d5372294e8c76f351db68"
+  integrity sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"


### PR DESCRIPTION
The version of @ember-template-lint/todo-utils currently used by this formatter contains APIs that have been deprecated in v10. In order to ensure we're on the latest version, and are using the newest APIs, this PR upgrades that library and ensures that tests pass.
