### PR TITLE
Support `--rule` option to narrow output of the formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ ember-template-lint . --format @scalvert/ember-template-lint-formatter-todo
 Running with the formatter will output a table of todos, ordered by due dates sorted by when they're due.
 
 <img width="784" alt="Todo Formatter" src="static/output.png">
+
+If you'd like to restrict the output to a specific rule ID, just pass the `--rule` option to `ember-template-lint`.
+
+```shell
+ember-template-lint . --rule "no-implicit-this:error" --format @scalvert/ember-template-lint-formatter-todo
+```

--- a/__tests__/get-rule-id-test.js
+++ b/__tests__/get-rule-id-test.js
@@ -1,0 +1,19 @@
+const getRuleId = require('../index').getRuleId;
+
+describe('get-rule-id', () => {
+  it('should be able to get rule ID from rule:severity', function () {
+    expect(getRuleId('no-implicit-this:error')).toEqual('no-implicit-this');
+  });
+
+  it('should be able to get rule ID from rule:["severity", { configObject }]', function () {
+    expect(
+      getRuleId('no-implicit-this:["error", { "allow": ["some-helper"] }]')
+    ).toEqual('no-implicit-this');
+    expect(
+      getRuleId('no-implicit-this:["warn", { "allow": ["some-helper"] }]')
+    ).toEqual('no-implicit-this');
+    expect(
+      getRuleId('no-implicit-this:["off", { "allow": ["some-helper"] }]')
+    ).toEqual('no-implicit-this');
+  });
+});

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -46,12 +46,12 @@ describe('Todo Formatter', () => {
     expect(mockConsole.toString()).toMatchInlineSnapshot(`
 "Lint Todos (8 found, 6 overdue)
 
-Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-action
+Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-action       
 Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
 Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
 Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
 Overdue 65 days 2021-03-01 addon/templates/components/truncate-multiline.hbs no-implicit-this
-Overdue 25 days 2021-04-10 addon/templates/just-yield.hbs                    no-yield-only
+Overdue 25 days 2021-04-10 addon/templates/just-yield.hbs                    no-yield-only   
 Due in 5 days   2021-05-10 addon/templates/components/button-toggle.hbs      no-implicit-this
 Due in 66 days  2021-07-10 addon/templates/components/button-toggle.hbs      no-implicit-this"
 `);

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -36,7 +36,6 @@ describe('Todo Formatter', () => {
     let todos = readJsonSync(
       path.resolve('./__tests__/__fixtures__/todos.json')
     );
-
     let formatter = new TodoSummaryFormatter({
       console: mockConsole,
     });
@@ -47,12 +46,37 @@ describe('Todo Formatter', () => {
     expect(mockConsole.toString()).toMatchInlineSnapshot(`
 "Lint Todos (8 found, 6 overdue)
 
-Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-action       
+Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-action
 Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
 Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
 Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
 Overdue 65 days 2021-03-01 addon/templates/components/truncate-multiline.hbs no-implicit-this
-Overdue 25 days 2021-04-10 addon/templates/just-yield.hbs                    no-yield-only   
+Overdue 25 days 2021-04-10 addon/templates/just-yield.hbs                    no-yield-only
+Due in 5 days   2021-05-10 addon/templates/components/button-toggle.hbs      no-implicit-this
+Due in 66 days  2021-07-10 addon/templates/components/button-toggle.hbs      no-implicit-this"
+`);
+  });
+
+  it('can format output from results for a single rule', () => {
+    let mockConsole = new MockConsole();
+    let todos = readJsonSync(
+      path.resolve('./__tests__/__fixtures__/todos.json')
+    );
+    let formatter = new TodoSummaryFormatter({
+      console: mockConsole,
+      rule: 'no-implicit-this:error',
+    });
+    let today = getDatePart(new Date('2021-05-05'));
+
+    formatter.print({}, {}, todos, today);
+
+    expect(mockConsole.toString()).toMatchInlineSnapshot(`
+"Lint Todos (6 found, 4 overdue)
+
+Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
+Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
+Overdue 65 days 2021-03-01 addon/templates/components/button-toggle.hbs      no-implicit-this
+Overdue 65 days 2021-03-01 addon/templates/components/truncate-multiline.hbs no-implicit-this
 Due in 5 days   2021-05-10 addon/templates/components/button-toggle.hbs      no-implicit-this
 Due in 66 days  2021-07-10 addon/templates/components/button-toggle.hbs      no-implicit-this"
 `);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ const {
   format,
 } = require('@lint-todo/utils');
 
+function getRuleId(rule) {
+  const indexOfSeparator = rule.indexOf(':') + 1;
+
+  return rule.substring(0, indexOfSeparator - 1);
+}
+
 class TodoSummaryFormatter {
   constructor(options = {}) {
     this.options = options;
@@ -36,6 +42,13 @@ class TodoSummaryFormatter {
           isWarn: isExpired(todo.warnDate, today.getTime()),
         };
       });
+
+    // a rule option has been passed to the CLI, meaning we want to restrict the output to just that rule
+    if (this.options.rule) {
+      let ruleId = getRuleId(this.options.rule);
+
+      sorted = sorted.filter((todo) => todo.ruleId === ruleId);
+    }
 
     this.console.log(
       `Lint Todos (${sorted.length} found, ${
@@ -75,5 +88,7 @@ class TodoSummaryFormatter {
     }
   }
 }
+
+TodoSummaryFormatter.getRuleId = getRuleId;
 
 module.exports = TodoSummaryFormatter;


### PR DESCRIPTION
The formatter currently outputs all todos, regardless of any other options. This PR adds support for providing the `--rule` option to narrow down what rules to output.

```shell
# will only output todos for the "no-implicit-this" rule
ember-template-lint . --rule "no-implicit-this:error" --format @scalvert/ember-template-lint-formatter-todo
``